### PR TITLE
URL-TextBox focused on page load

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -115,7 +115,7 @@
     <form action="/" method="post" enctype="multipart/form-data">
       Bild:<input name="image" type="file"><br>
       oder<br>
-      URL:<input name="url" type="text"><br>
+      URL:<input name="url" type="text" autofocus><br>
       <input type="submit" value="rep0st?">
     </form>
   </div>


### PR DESCRIPTION
Added the HTML 5 attribute _`autofocus`_ to the URL-`<input>`.
(Only works for IE versions >=10)
